### PR TITLE
CreatePlayListの入力値のエラー処理をhandlerに移した

### DIFF
--- a/go/src/MyPIPE/domain/model/PlayList.go
+++ b/go/src/MyPIPE/domain/model/PlayList.go
@@ -21,6 +21,12 @@ func NewPlayListID(playListID uint64)(PlayListID,error){
 type PlayListName string
 
 func NewPlayListName(playListName string)(PlayListName,error){
+	err := validation.Validate(playListName,
+		validation.Required,
+	)
+	if err != nil {
+		return PlayListName(""), err
+	}
 	return PlayListName(playListName),nil
 }
 

--- a/go/src/MyPIPE/handler/PlayList.go
+++ b/go/src/MyPIPE/handler/PlayList.go
@@ -1,16 +1,19 @@
 package handler
 
 import (
+	"MyPIPE/domain/model"
 	"MyPIPE/infra"
 	"MyPIPE/usecase"
+	"encoding/json"
 	jwt "github.com/appleboy/gin-jwt/v2"
 	"github.com/gin-gonic/gin"
 	"net/http"
 )
 
 func CreatePlayList(c *gin.Context){
-	var playListDTO usecase.CreatePlayListJson
-	bindErr := c.Bind(&playListDTO)
+	//var playListDTO usecase.CreatePlayListJson
+	var playListJson CreatePlayListJson
+	bindErr := c.Bind(&playListJson)
 	if bindErr != nil{
 		c.JSON(http.StatusBadRequest, gin.H{
 			"result": "Error.",
@@ -20,12 +23,36 @@ func CreatePlayList(c *gin.Context){
 		return
 	}
 	userId := uint64(jwt.ExtractClaims(c)["id"].(float64))
-	playListDTO.UserID = userId
+	playListJson.UserID = userId
+
+	validationErrors := make(map[string]string)
+	var CreatePlayListDTO usecase.CreatePlayListDTO
+	var userIDErr error
+	CreatePlayListDTO.UserID,userIDErr = model.NewUserID(playListJson.UserID)
+	if userIDErr != nil{
+		validationErrors["user_id"] = userIDErr.Error()
+	}
+
+	var playListNameErr error
+	CreatePlayListDTO.PlayListName,playListNameErr = model.NewPlayListName(playListJson.PlayListName)
+	if playListNameErr != nil{
+		validationErrors["play_list_name"] = playListNameErr.Error()
+	}
+
+	if len(validationErrors) != 0{
+		validationErrors,_ := json.Marshal(validationErrors)
+		c.JSON(http.StatusBadRequest, gin.H{
+			"result": "Validation Error.",
+			"messages": string(validationErrors),
+		})
+		c.Abort()
+		return
+	}
 
 	userPersistence := infra.NewUserPersistence()
 	playListPersistence := infra.NewPlayListPersistence()
 	createPlayListUsecase := usecase.NewCreatePlayList(userPersistence,playListPersistence)
-	createPlayListUsecaseErr := createPlayListUsecase.CreatePlayList(playListDTO)
+	createPlayListUsecaseErr := createPlayListUsecase.CreatePlayList(CreatePlayListDTO)
 	if createPlayListUsecaseErr != nil{
 		c.JSON(http.StatusBadRequest, gin.H{
 			"result": "Error.",
@@ -39,4 +66,9 @@ func CreatePlayList(c *gin.Context){
 		"result": "Success.",
 		"messages": "OK",
 	})
+}
+
+type CreatePlayListJson struct{
+	UserID uint64
+	PlayListName string `json:"play_list_name"`
 }

--- a/go/src/MyPIPE/usecase/CreatePlayList.go
+++ b/go/src/MyPIPE/usecase/CreatePlayList.go
@@ -20,19 +20,11 @@ func NewCreatePlayList(u repository.UserRepository,p repository.PlayListReposito
 	}
 }
 
-func (c CreatePlayList)CreatePlayList(createPlayList CreatePlayListJson)error{
+func (c CreatePlayList)CreatePlayList(createPlayList CreatePlayListDTO)error{
 	playList := model.NewPlayList()
-	var playListUserIDErr error
-	playList.UserID,playListUserIDErr = model.NewUserID(createPlayList.UserID)
-	if playListUserIDErr != nil{
-		return playListUserIDErr
-	}
+	playList.UserID = createPlayList.UserID
 
-	var playListNameErr error
-	playList.Name,playListNameErr = model.NewPlayListName(createPlayList.PlayListName)
-	if playListNameErr != nil{
-		return playListNameErr
-	}
+	playList.Name = createPlayList.PlayListName
 
 	playListRepository := infra.NewPlayListPersistence()
 	checkSameUserIDAndNameExistsService := domain_service.NewCheckSameUserIDAndNameExists(playListRepository)
@@ -51,7 +43,7 @@ func (c CreatePlayList)CreatePlayList(createPlayList CreatePlayListJson)error{
 	return nil
 }
 
-type CreatePlayListJson struct{
-	UserID uint64
-	PlayListName string `json:"playlist_name"`
+type CreatePlayListDTO struct{
+	UserID model.UserID
+	PlayListName model.PlayListName
 }


### PR DESCRIPTION
## 内容
・再生リスト作成の入力値のエラー処理を、CreatePlayListUsecaseからhandlerへ移した
--go/src/MyPIPE/handler/PlayList.go
--go/src/MyPIPE/usecase/CreatePlayList.go