### PR TITLE
play_listsテーブルに再生リストの説明descriptionカラムを追加

### DIFF
--- a/go/src/MyPIPE/Migrations/000021_add_description_column_to_play_lists_table.down.sql
+++ b/go/src/MyPIPE/Migrations/000021_add_description_column_to_play_lists_table.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE play_lists DROP COLUMN description;

--- a/go/src/MyPIPE/Migrations/000021_add_description_column_to_play_lists_table.up.sql
+++ b/go/src/MyPIPE/Migrations/000021_add_description_column_to_play_lists_table.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE play_lists ADD COLUMN description LONGTEXT NULL AFTER name;

--- a/mysql/my.cnf
+++ b/mysql/my.cnf
@@ -4,6 +4,7 @@ ft_min_word_len = 1
 innodb_ft_min_token_size = 1
 innodb_ft_enable_stopword = OFF
 ngram_token_size = 1
+sql_mode = STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION
 
 [mysql]
 default-character-set=utf8mb4


### PR DESCRIPTION
## 内容
・play_listsテーブルに再生リストの説明descriptionカラムを追加
go/src/MyPIPE/Migrations/000021_add_description_column_to_play_lists_table.up.sql 
go/src/MyPIPE/Migrations/000021_add_description_column_to_play_lists_table.down.sql 
